### PR TITLE
1.0.2 Fixes

### DIFF
--- a/components/tredly-host-bash/tredly-host
+++ b/components/tredly-host-bash/tredly-host
@@ -18,8 +18,8 @@ declare -a _SUBCOMMANDS
 declare -A _FLAGS
 
 # versioning
-_VERSIONNUMBER="1.0.1"
-_VERSIONDATE="June 24 2016"
+_VERSIONNUMBER="1.0.2"
+_VERSIONDATE="June 27 2016"
 
 _SHOW_HELP=false
 _ARGS=($@)

--- a/components/tredly-install/kernel/TREDLY
+++ b/components/tredly-install/kernel/TREDLY
@@ -3,7 +3,6 @@ ident TREDLY
 
 nooptions       SCTP   # Stream Control Transmission Protocol
 options         VIMAGE # VNET/Vimage support
-#options         RACCT  # Resource containers (Now in 10.3 GENERIC kernel)
-#options         RCTL   # same as above (Now in 10.3 GENERIC kernel)
-nooptions       RACCT_DEFAULT_TO_DISABLED
-nomakeoptions   DEBUG
+options         RACCT  # Resource containers (Now in 10.3 GENERIC kernel)
+options         RCTL   # same as above (Now in 10.3 GENERIC kernel)
+#nooptions       RACCT_DEFAULT_TO_DISABLED

--- a/components/tredly-install/kernel/TREDLYISO
+++ b/components/tredly-install/kernel/TREDLYISO
@@ -1,0 +1,9 @@
+include GENERIC
+ident TREDLY
+
+nooptions       SCTP   # Stream Control Transmission Protocol
+options         VIMAGE # VNET/Vimage support
+#options         RACCT  # Resource containers (Now in 10.3 GENERIC kernel)
+#options         RCTL   # same as above (Now in 10.3 GENERIC kernel)
+nooptions       RACCT_DEFAULT_TO_DISABLED
+nomakeoptions   DEBUG

--- a/components/tredly-install/os/installerconfig
+++ b/components/tredly-install/os/installerconfig
@@ -50,7 +50,7 @@ export ZFSBOOT_DATASETS="
     /tredly/ptn/default/remotecontainers    mountpoint=/tredly/ptn/default/remotecontainers
 "
 
-export DISTRIBUTIONS="base.txz kernel-tredly.txz lib32.txz ports.txz tredly.txz"
+export DISTRIBUTIONS="base.txz kernel-tredly.txz lib32.txz ports.txz"
 
 #!/bin/sh
 
@@ -85,7 +85,10 @@ hostname tredly
 echo "fdesc                   /dev/fd fdescfs rw              0       0" >> /etc/fstab
 
 echo "Installing Tredly"
-
+env ASSUME_ALWAYS_YES=YES pkg bootstrap
+env ASSUME_ALWAYS_YES=YES pkg install -y git bash
+mkdir -p /tredlyinstall
+/usr/local/bin/git clone https://github.com/tredly/tredly.git /tredlyinstall
 /tredlyinstall/install.sh
 
 # clean up the install directory

--- a/components/tredly-libs/bash-common/ip4_functions.sh
+++ b/components/tredly-libs/bash-common/ip4_functions.sh
@@ -445,14 +445,14 @@ function generate_mac_address() {
 # changes the hosts network details
 function ip4_set_host_network() {
     local _interface="${1}"
-    local _ip4="${2}"
+    local _ip4Arg="${2}"
 
-    local _ip4CIDR=$( rcut "${_ip4}" '/' )
-    local _ip4=$( lcut "${_ip4}" '/' )
+    local _ip4CIDR=$( rcut "${_ip4Arg}" '/' )
+    local _ip4=$( lcut "${_ip4Arg}" '/' )
 
     local _exitCode=0
     
-    e_header "Setting Tredly host IP address to ${2} on interface ${_interface}"
+    e_header "Setting Tredly host IP address to ${_ip4} on interface ${_interface}"
     
 
     if [[ -z "${_ip4}" ]]; then

--- a/components/tredly-libs/python-common/includes/defines.py
+++ b/components/tredly-libs/python-common/includes/defines.py
@@ -49,8 +49,8 @@ global VERSON_NUMBER
 global VERSION_DATE
 
 # set version/date
-VERSION_NUMBER = "1.0.1"
-VERSION_DATE = "June 24 2016"
+VERSION_NUMBER = "1.0.2"
+VERSION_DATE = "June 27 2016"
 
 # ZFS Dataset locations
 ZFS_ROOT = "zroot"

--- a/components/tredly/tredly
+++ b/components/tredly/tredly
@@ -18,8 +18,8 @@ declare -a _SUBCOMMANDS
 declare -a _ENTIREFLAGS
 
 # versioning
-_VERSIONNUMBER="1.0.1"
-_VERSIONDATE="June 24 2016"
+_VERSIONNUMBER="1.0.2"
+_VERSIONDATE="June 27 2016"
 
 _SHOW_HELP=false
 _ARGS=($@)

--- a/doc/zfs.md
+++ b/doc/zfs.md
@@ -82,6 +82,8 @@ None
 * com.tredly.registered_dns_names - array of hostnames associated with this container
 * com.tredly.layer4proxytcp - array of tcp ports set up for layer 4 proxy
 * com.tredly.layer4proxyudp - array of udp ports set up for layer 4 proxy
+* com.tredly.startepoch - array of epoch times of when this container has previously been started
+
 
 ## Partition Properties
 * quota - max disk usage


### PR DESCRIPTION
Fix: installer: use tredly password to set tredly user password (formerly used root password)
Fix: installer: fix tredly kernel recompile
Fix: installer: change renamed files to be .(epochtime) instead of .old (allows for archiving of user files)
Fix: installer: if tredly user is already created then modify the user. otherwise create the user
Fix: tredly-build: only run the oncreate commands/create the onstop script on first boot of container
Fix: tredly-host: change variable name for function ip4_set_host_network to mitigate namespace issues
tredly-build: Add "startepoch" array to ZFS for containers to track when they have been started & to facilitate the above oncreate command fix
Change tredly iso installer to pull from github instead of using local files
Raise versions to 1.0.2